### PR TITLE
Fix T-Coffee installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,18 +61,21 @@ rm T-COFFEE_installer_Version_13.45.0.4846264_linux_x64.tar.gz
 ! Explain what happend in the three commands above
 ```
 
-First, set this environment variable to allow t_coffee to properly run (this is important!):
+***IMPORTANT:*** Next, before you run T-Coffee at all, you first have to run the following command:
 ```bash
 export MAX_N_PID_4_TCOFFEE=$(sysctl -n kernel.pid_max)
 ```
+*You don't need to understand this command, but if you are curious: All processess (programs) running on a computer are identified by a Process ID (PID). The version of T-Coffee we use has a known bug in operating systems like the one installed on the UiO server we are using. T-Coffee essentially assumes wrongly what the highest possible PID is, so we need to ask that information from the UiO server itself (`sysctl -n kernel.pid_max`) and then force T-Coffee to use that value (`export MAX_N_PID_4_TCOFFEE`).*
 
-Then, try to execute the the `t_coffee` program:
+Having run the above command, you can now try to execute the the `t_coffee` program:
 ```bash
 ./t_coffee
 ```
 
-If successful, there should be lots of options output to the screen
-
+If successful, there should be lots of options output to the screen.
+```diff
+! Verify that there is no "ERROR" message at the bottom of the output when you ran the T-Coffee command.
+```
 
 ## 5.3 Performing multiple sequence alignments on globin sequences
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ rm T-COFFEE_installer_Version_13.45.0.4846264_linux_x64.tar.gz
 ! Explain what happend in the three commands above
 ```
 
-***IMPORTANT:*** Next, before you run T-Coffee at all, you first have to run the following command:
+***IMPORTANT:*** Next, before you run T-Coffee at all, you first have to run the following command. You have to do this in every terminal session where you want to use T-Coffee, i.e. if you later log out and back into the UiO server, you need to repeat this before running T-Coffee:
 ```bash
 export MAX_N_PID_4_TCOFFEE=$(sysctl -n kernel.pid_max)
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ As we learned in [Module 1 (exercise 1.4.11)](https://github.com/BIOS3010/Module
 
 - Execute the following command to download the T-Coffee program:
 ```bash
-curl -O https://s3.eu-central-1.amazonaws.com/tcoffee-packages/Stable/Latest/T-COFFEE_installer_Version_13.45.0.4846264_linux_x64.tar.gz
+curl -O https://s3.eu-central-1.amazonaws.com/tcoffee-packages/Archives/T-COFFEE_installer_Version_13.45.0.4846264_linux_x64.tar.gz
 ```
 
 ```diff

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ rm T-COFFEE_installer_Version_13.45.0.4846264_linux_x64.tar.gz
 
 First, set this environment variable to allow t_coffee to properly run (this is important!):
 ```bash
-export MAX_N_PID_4_TCOFFEE=2000000
+export MAX_N_PID_4_TCOFFEE=$(sysctl -n kernel.pid_max)
 ```
 
 Then, try to execute the the `t_coffee` program:


### PR DESCRIPTION
The T-Coffee version was no longer available at the same URL, but had been archived. This version of T-Coffee also requires (due to a bug) that the kernel's maximum process ID is specified as an environmental variable on 64-Bit Linux; this is now specified with reference to the kernel's max value instead of a hardcoded number.

Added a quick exercise to specify how students should ensure there is no error in T-Coffee.

Runs as expected on the server for me!